### PR TITLE
remove AllowedVersions constraint on EngineVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm i @cfn-modules/rds-postgres
 
 ## Usage
 
-```
+```yaml
 ---
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'cfn-modules example'
@@ -179,7 +179,7 @@ Resources:
       <td>
         set this to the version of PostgreSQL you want to use.
         You can run the following command to get the list of PostgreSQL versions supported by AWS RDS:<br />
-        `aws rds describe-db-engine-versions --engine postgres --query "DBEngineVersions[].EngineVersion"`
+        <code>aws rds describe-db-engine-versions --engine postgres --query "DBEngineVersions[].EngineVersion"</code>
       </td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Resources:
         DBMasterUserPassword: '' # required if DBSnapshotIdentifier is not set
         DBMultiAZ: 'true' # optional
         SubDomainNameWithDot: 'postgres.' # optional
-        EngineVersion: '9.6.8' # set this to the latest available version when launching!
+        # set this to the latest available version when launching!  Use command below to get list of engineversions available in AWS.
+        # aws rds describe-db-engine-versions --engine postgres --query "DBEngineVersions[].EngineVersion"
+        EngineVersion: '9.6.8'
         EnableIAMDatabaseAuthentication: 'false' # optional
       TemplateURL: './node_modules/@cfn-modules/rds-postgres/module.yml'
 ```
@@ -174,7 +176,11 @@ Resources:
       <td>PostgreSQL version</td>
       <td>9.6.8</td>
       <td>no</td>
-      <td>['11.2', '11.1', '10.7', '10.6', '10.5', '10.4', '10.3', '10.1', '9.6.12', '9.6.8']</td>
+      <td>
+        set this to the version of PostgreSQL you want to use.
+        You can run the following command to get the list of PostgreSQL versions supported by AWS RDS:<br />
+        `aws rds describe-db-engine-versions --engine postgres --query "DBEngineVersions[].EngineVersion"`
+      </td>
     </tr>
     <tr>
       <td>EnableIAMDatabaseAuthentication</td>

--- a/module.yml
+++ b/module.yml
@@ -83,8 +83,7 @@ Parameters:
   EngineVersion:
     Description: 'PostgreSQL version.'
     Type: String
-    Default: '9.6.8'
-    AllowedValues: ['11.2', '11.1', '10.7', '10.6', '10.5', '10.4', '10.3', '10.1', '9.6.12', '9.6.8', '9.5.16', '9.4.21', '9.3.25'] # aws rds describe-db-engine-versions --engine postgres --query "DBEngineVersions[].EngineVersion"
+    Default: '9.6.8' # aws rds describe-db-engine-versions --engine postgres --query "DBEngineVersions[].EngineVersion"
   EnableIAMDatabaseAuthentication:
     Description: 'Enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html).'
     Type: String


### PR DESCRIPTION
Current list is several years old (several major releases).  It is a maintenance burden to keep it up to date with newer versions.  Seems simpler to just let AWS reject the stack if you use an invalid version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
